### PR TITLE
Allow xdebug port to be configurable

### DIFF
--- a/lamp/tasks/install_xdebug.yml
+++ b/lamp/tasks/install_xdebug.yml
@@ -1,4 +1,8 @@
 ---
+- set_fact:
+    xdebug_port: 9000
+  when: xdebug_port is not defined
+
 - name: setup xdebug config
   become: yes
   template:

--- a/lamp/templates/20-xdebug.ini
+++ b/lamp/templates/20-xdebug.ini
@@ -2,4 +2,4 @@ zend_extension=xdebug.so
 
 xdebug.remote_enable=1
 xdebug.remote_host=10.0.2.2
-xdebug.remote_port=9000
+xdebug.remote_port={{ xdebug_port }}


### PR DESCRIPTION
I added this because I was having some issues with port 9000 being busy. I’m not sure if it’s PHPstorm itself or what, but it’s nice to be able to override if neccessary.