### PR TITLE
set default for trust_cert for when not defined in the project

### DIFF
--- a/lamp/tasks/create_certificate.yml
+++ b/lamp/tasks/create_certificate.yml
@@ -1,4 +1,8 @@
 ---
+- set_fact:
+    trust_cert: 1
+  when: trust_cert is not defined
+
 # h/t to http://stackoverflow.com/a/21494483/1676099
 - name: add SAN to openssl conf file
   become: yes


### PR DESCRIPTION
otherwise the "copy cert to host system" fails.

https://github.com/fostermadeco/ansible-roles/commit/8643a3ed0af38d1b9f011b526342063e382b2163