### PR TITLE
Put vagrant user in ssl-cert group

### DIFF
--- a/lamp/tasks/create_certificate.yml
+++ b/lamp/tasks/create_certificate.yml
@@ -49,6 +49,19 @@
   tags:
       - cert
 
+- name: Ensure ssl-cert group exists
+  become: yes
+  group:
+    name: ssl-cert
+    state: present
+
+- name: loosen cert permissions — only because this is local
+  become: yes
+  user:
+    name: vagrant
+    append: yes
+    groups: ssl-cert
+
 - name: copy cert to host system
   become: yes
   fetch:


### PR DESCRIPTION
Effectively allows BrowserSync to use existing SSL key in place
