### PR TITLE
Allows installation of php modules using --no-install-recommends flag

### DIFF
--- a/lamp/tasks/install_php.yml
+++ b/lamp/tasks/install_php.yml
@@ -24,6 +24,16 @@
   tags:
       - php_modules
 
+- name: install legacy php modules
+  become: yes
+  apt:
+    name: "php{{ php_version if php_version != 7.0 else '' }}-{{ item }}"
+    state: present
+    install_recommends: no
+  with_items: "{{ php_legacy_modules | default([]) }}"
+  tags:
+    - php_legacy_modules
+
 - name: ensure php-fpm is started
   become: yes
   service:


### PR DESCRIPTION
Inside of "group_vars/all" Devs would set the item list as the below example shows:

php_legacy_modules:
    - apcu