### PR TITLE
add xdebug config to enabled profiler

### DIFF
--- a/lamp/templates/20-xdebug.ini
+++ b/lamp/templates/20-xdebug.ini
@@ -3,3 +3,7 @@ zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_host=10.0.2.2
 xdebug.remote_port={{ xdebug_port }}
+
+xdebug.profiler_enable=0
+xdebug.profiler_enable_trigger=1
+xdebug.profiler_output_dir="/var/www/{{ hostname }}"


### PR DESCRIPTION
This commit follows https://www.jetbrains.com/help/phpstorm/enabling-profiling-with-xdebug.html to allow users to easily enabled the xdebug profiler through a browser extension such as https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc

Upon enabling a file is created in the project's root which can be analyzed with PHPStorm (for example) with this [profiler snapshot analyzer](https://www.jetbrains.com/help/phpstorm/analyzing-xdebug-profiling-data.html)

After this is merged, I can put together a slightly more comprehensive guide on usage on using this feature in [our standards wiki](https://github.com/fostermadeco/standards/wiki)
