### PR TITLE
Allow state attribute to override mysql settings

### DIFF
--- a/lamp/tasks/install_mysql.yml
+++ b/lamp/tasks/install_mysql.yml
@@ -68,6 +68,7 @@
   ini_file:
       dest: "/etc/mysql/my.cnf"
       option: "{{ item.option }}"
+      state: "{{ item.state | default('present') }}"
       section: "{{ item.section | default('mysqld') }}"
       value: "{{ item.value }}"
   notify:


### PR DESCRIPTION
Wanted to be able to remove an ini setting but was only possible with access to the `state` attribute. There should be no side effects to any user doing typical provisioning of vagrant.