### PR TITLE
Upgrading to bionic64

### DIFF
--- a/lamp/tasks/install_mysql.yml
+++ b/lamp/tasks/install_mysql.yml
@@ -20,6 +20,7 @@
   mysql_user:
       name: root
       password: root
+      login_unix_socket: /var/run/mysqld/mysqld.sock
       check_implicit_admin: true
 
 - name: create root .my.cnf

--- a/lamp/tasks/install_pip.yml
+++ b/lamp/tasks/install_pip.yml
@@ -1,0 +1,6 @@
+- name: Install pip
+  become: yes
+  apt:
+    name: python3-pip
+    update_cache: yes
+    state: present

--- a/lamp/tasks/install_pymysql.yml
+++ b/lamp/tasks/install_pymysql.yml
@@ -1,0 +1,5 @@
+- name: Make sure pymysql is present
+  become: yes
+  pip:
+    name: pymysql
+    state: present

--- a/lamp/tasks/main.yml
+++ b/lamp/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - include: create_certificate.yml
 - include: install_apache.yml
+- include: install_pip.yml
+- include: install_pymysql.yml
 - include: install_mysql.yml
 - include: install_php.yml
 - include: install_phpunit.yml

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-ubuntu/xenial64
+ubuntu/bionic64


### PR DESCRIPTION
The php7.2-fpm repository is no longer available. I went ahead and bumped the OS version to bionic64 to resolve this. Not sure if this was the best way, and I know you mentioned using a different repository in Slack, but this seems to work consistently in my tests. 